### PR TITLE
Partner consent and CSP sample update

### DIFF
--- a/secure-app-model/keyvault/CSPApplication/App.config
+++ b/secure-app-model/keyvault/CSPApplication/App.config
@@ -10,7 +10,7 @@
     <add key="ida:CSPApplicationSecret" value="" />
 
     <!-- Endpoint address for the instance of Azure KeyVault -->
-    <add key="KeyVaultEndpoint" value="https://partnercenter.vault.azure.net/" />
+    <add key="KeyVaultEndpoint" value="" />
     
     <!-- AppID that is given access for keyvault to store the refresh tokens -->
     <add key="ida:KeyVaultClientId" value="" />

--- a/secure-app-model/keyvault/CSPApplication/App.config
+++ b/secure-app-model/keyvault/CSPApplication/App.config
@@ -10,7 +10,7 @@
     <add key="ida:CSPApplicationSecret" value="" />
 
     <!-- Endpoint address for the instance of Azure KeyVault -->
-    <add key="KeyVaultEndpoint" value="" />
+    <add key="KeyVaultEndpoint" value="https://partnercenter.vault.azure.net/" />
     
     <!-- AppID that is given access for keyvault to store the refresh tokens -->
     <add key="ida:KeyVaultClientId" value="" />
@@ -31,11 +31,11 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.4.2.0" newVersion="4.4.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/secure-app-model/keyvault/CSPApplication/CSPApplication.csproj
+++ b/secure-app-model/keyvault/CSPApplication/CSPApplication.csproj
@@ -6,8 +6,8 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{9283AF7A-6CA9-4373-93CB-F5D2130E1889}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <RootNamespace>CPVApplication</RootNamespace>
-    <AssemblyName>CPVApplication</AssemblyName>
+    <RootNamespace>CSPApplication</RootNamespace>
+    <AssemblyName>CSPApplication</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -33,13 +33,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Azure.KeyVault, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.KeyVault.3.0.1\lib\net452\Microsoft.Azure.KeyVault.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Azure.KeyVault.3.0.2\lib\net452\Microsoft.Azure.KeyVault.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.WebKey, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.KeyVault.WebKey.3.0.1\lib\net452\Microsoft.Azure.KeyVault.WebKey.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Azure.KeyVault.WebKey.3.0.2\lib\net452\Microsoft.Azure.KeyVault.WebKey.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=4.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.4.4.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=4.4.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.4.4.2\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.3.18\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
@@ -56,8 +56,8 @@
     <Reference Include="Microsoft.Store.PartnerCenter.Models, Version=1.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Store.PartnerCenter.1.10.0\lib\Net45\Microsoft.Store.PartnerCenter.Models.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -93,6 +93,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Exceptions\AuthenticationException.cs" />
+    <Compile Include="Models\AuthenticationResponse.cs" />
+    <Compile Include="Models\AuthenticationResult.cs" />
+    <Compile Include="Network\PartnerServiceClient.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utilities\AuthorizationUtilities.cs" />
@@ -105,5 +109,6 @@
     </None>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/secure-app-model/keyvault/CSPApplication/Exceptions/AuthenticationException.cs
+++ b/secure-app-model/keyvault/CSPApplication/Exceptions/AuthenticationException.cs
@@ -1,0 +1,104 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="AuthenticationException.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace CSPApplication.Exceptions
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// Exception that is throw when an authentication error is encountered.
+    /// </summary>
+    [Serializable]
+    public class AuthenticationException : Exception
+    {
+        /// <summary>
+        /// The error code field name used in serialization.
+        /// </summary>
+        [NonSerialized]
+        private const string ErrorCodeFieldName = "ErrorCode";
+
+        /// <summary>
+        /// The error code encountering when authenticating.
+        /// </summary>
+        [NonSerialized]
+        private readonly string errorCode;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthenticationException" /> class.
+        /// </summary>
+        public AuthenticationException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthenticationException" /> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public AuthenticationException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthenticationException" /> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="errorCode">The error code encountered when authenticating.</param>
+        public AuthenticationException(string errorCode, string message) : base(message)
+        {
+            this.errorCode = errorCode;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthenticationException" /> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">
+        /// The exception that is the cause of the current exception, or a null reference
+        /// (Nothing in Visual Basic) if no inner exception is specified.
+        /// </param>
+        public AuthenticationException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthenticationException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
+        protected AuthenticationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            errorCode = info.GetValue(ErrorCodeFieldName, typeof(string)) as string;
+        }
+
+        /// <summary>
+        /// Gets the error code encountered when authenticating.
+        /// </summary>
+        public string ErrorCode => errorCode;
+
+        /// <summary>
+        /// When overridden in a derived class, sets the <see cref="SerializationInfo" /> with information about the exception.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
+        /// <PermissionSet>
+        ///   <IPermission class="System.Security.Permissions.FileIOPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Read="*AllFiles*" PathDiscovery="*AllFiles*" />
+        ///   <IPermission class="System.Security.Permissions.SecurityPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Flags="SerializationFormatter" />
+        /// </PermissionSet>
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException(nameof(info));
+            }
+
+            info.AddValue(ErrorCodeFieldName, errorCode);
+
+            base.GetObjectData(info, context);
+        }
+    }
+}

--- a/secure-app-model/keyvault/CSPApplication/Models/AuthenticationResponse.cs
+++ b/secure-app-model/keyvault/CSPApplication/Models/AuthenticationResponse.cs
@@ -1,0 +1,50 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="AuthenticationResponse.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace CSPApplication.Models
+{
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// Represents a response for the authentication system.
+    /// </summary>
+    [DataContract]
+    internal sealed class AuthenticationResponse
+    {
+        [DataMember(IsRequired = false, Name = "access_token")]
+        public string AccessToken { get; set; }
+
+        [DataMember(IsRequired = false, Name = "created_on")]
+        public long CreatedOn { get; set; }
+
+        [DataMember(IsRequired = false, Name = "error")]
+        public string Error { get; set; }
+
+        [DataMember(IsRequired = false, Name = "error_codes")]
+        public string[] ErrorCodes { get; set; }
+
+        [DataMember(IsRequired = false, Name = "error_description")]
+        public string ErrorDescription { get; set; }
+
+        [DataMember(IsRequired = false, Name = "expires_in")]
+        public long ExpiresIn { get; set; }
+
+        [DataMember(IsRequired = false, Name = "expires_on")]
+        public long ExpiresOn { get; set; }
+
+        [DataMember(IsRequired = false, Name = "id_token")]
+        public string IdTokenString { get; set; }
+
+        [DataMember(IsRequired = false, Name = "refresh_token")]
+        public string RefreshToken { get; set; }
+
+        [DataMember(IsRequired = false, Name = "resource")]
+        public string Resource { get; set; }
+
+        [DataMember(IsRequired = false, Name = "token_type")]
+        public string TokenType { get; set; }
+    }
+}

--- a/secure-app-model/keyvault/CSPApplication/Models/AuthenticationResult.cs
+++ b/secure-app-model/keyvault/CSPApplication/Models/AuthenticationResult.cs
@@ -1,0 +1,57 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="AuthenticationResult.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace CSPApplication.Models
+{
+    using System;
+
+    /// <summary>
+    /// Contains the results of one token acquisition operation.
+    /// </summary>
+    public sealed class AuthenticationResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthenticationResult" /> class.
+        /// </summary>
+        /// <param name="authResponse"></param>
+        internal AuthenticationResult(AuthenticationResponse authResponse)
+        {
+            AccessToken = authResponse.AccessToken;
+            AccessTokenType = authResponse.TokenType;
+            ExpiresOn = DateTime.UtcNow + TimeSpan.FromSeconds(authResponse.ExpiresIn);
+            IdToken = authResponse.IdTokenString;
+            RefreshToken = authResponse.RefreshToken;
+        }
+
+        /// <summary>
+        /// Gets the access token requested.
+        /// </summary>
+        public string AccessToken { get; private set; }
+
+        /// <summary>
+        /// Gets the type of access token returned.
+        /// </summary>
+        public string AccessTokenType { get; private set; }
+
+        /// <summary>
+        /// Gets the point in time in which the access token returned in the <see cref="AccessToken" /> property ceases to be valid.
+        /// </summary>
+        /// <remarks>
+        /// This value is calculated based on current UTC time measured locally and the value expiresIn received from the service.
+        /// </remarks>
+        public DateTimeOffset ExpiresOn { get; private set; }
+
+        /// <summary>
+        /// Gets the entire ID token if returned by the service or null if no ID token is returned.
+        /// </summary>
+        public string IdToken { get; private set; }
+
+        /// <summary>
+        /// Gets the refresh token associated with the requested access token. Note: not all operations will return a refresh token.
+        /// </summary>
+        public string RefreshToken { get; private set; }
+    }
+}

--- a/secure-app-model/keyvault/CSPApplication/Network/PartnerServiceClient.cs
+++ b/secure-app-model/keyvault/CSPApplication/Network/PartnerServiceClient.cs
@@ -1,0 +1,111 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="PartnerServiceClient.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace CSPApplication.Network
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Exceptions;
+    using Microsoft.Rest;
+    using Models;
+    using Newtonsoft.Json;
+
+    public sealed class PartnerServiceClient : ServiceClient<PartnerServiceClient>
+    {
+        /// <summary>
+        /// The settings to be used when serializing and de-serializing JSON.
+        /// </summary>
+        private readonly JsonSerializerSettings serializerSettings;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartnerServiceClient" /> class.
+        /// </summary>
+        /// <param name="httpClient">The HTTP client to be used.</param>
+        public PartnerServiceClient(HttpClient httpClient)
+            : base(httpClient, false)
+        {
+            serializerSettings = new JsonSerializerSettings
+            {
+                DateFormatHandling = DateFormatHandling.IsoDateFormat,
+                DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+                NullValueHandling = NullValueHandling.Ignore,
+                ReferenceLoopHandling = ReferenceLoopHandling.Serialize
+            };
+        }
+
+        /// <summary>
+        /// Refreshes the access token using a refresh token.
+        /// </summary>
+        /// <param name="authority">Address of the authority to issue the token.></param>
+        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
+        /// <param name="refreshToken">The refresh token to be used to obtain a new access token.</param>
+        /// <param name="clientId">Identifier of the client requesting the token.</param>
+        /// <param name="clientSecret">Secret of the client requesting the token.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>An instance of <see cref="AuthenticationResult"/> that represents the access token.</returns>
+        public async Task<AuthenticationResult> RefreshAccessTokenAsync(string authority, string resource, string refreshToken, string clientId, string clientSecret = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Dictionary<string, string> content;
+            HttpResponseMessage response = null;
+            AuthenticationResponse authResponse;
+
+            try
+            {
+                using (HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, new Uri(authority)))
+                {
+                    content = new Dictionary<string, string>
+                    {
+                        ["client_id"] = clientId,
+                        ["grant_type"] = "refresh_token",
+                        ["refresh_token"] = refreshToken,
+                        ["resource"] = resource
+                    };
+
+                    if (!string.IsNullOrEmpty(clientSecret))
+                    {
+                        content.Add("client_secret", clientSecret);
+                    }
+
+                    request.Content = new FormUrlEncodedContent(content);
+
+                    response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+                    authResponse = await HandleAuthenticationResponseAsync(response).ConfigureAwait(false);
+
+                    return new AuthenticationResult(authResponse);
+                }
+            }
+            finally
+            {
+                response?.Dispose();
+            }
+        }
+
+        private async Task<AuthenticationResponse> HandleAuthenticationResponseAsync(HttpResponseMessage response)
+        {
+            AuthenticationResponse entity;
+            string content;
+
+            content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            entity = JsonConvert.DeserializeObject<AuthenticationResponse>(content, serializerSettings);
+
+            if (response.IsSuccessStatusCode)
+            {
+                return entity;
+            }
+
+            if (entity == null)
+            {
+                throw new AuthenticationException(response.StatusCode.ToString(), response.ReasonPhrase);
+            }
+
+            throw new AuthenticationException(entity.Error, entity.ErrorDescription);
+        }
+    }
+}

--- a/secure-app-model/keyvault/CSPApplication/Program.cs
+++ b/secure-app-model/keyvault/CSPApplication/Program.cs
@@ -8,19 +8,32 @@ namespace CSPApplication
 {
     using System;
     using System.Configuration;
+    using System.Net.Http;
     using System.Threading.Tasks;
     using CSPApplication.Utilities;
     using Microsoft.Store.PartnerCenter;
     using Microsoft.Store.PartnerCenter.Extensions;
     using Microsoft.Store.PartnerCenter.Models;
     using Microsoft.Store.PartnerCenter.Models.Users;
+    using Models;
+    using Network;
     using Newtonsoft.Json;
 
     internal class Program
     {
         /// <summary>
+        /// The client used to perform HTTP operations.
+        /// </summary>
+        private static readonly HttpClient httpClient = new HttpClient();
+
+        /// <summary>
+        /// The client used to request resources such as access tokens.
+        /// </summary>
+        private static PartnerServiceClient serviceClient;
+
+        /// <summary>
         /// The following code assumes that the context of the partner is pre determined by some external code 
-        /// (based on marketplace application logic: either by product or by partner context)
+        /// (based on application logic: either by product or by partner context)
         /// </summary>
 
         private static readonly string CSPApplicationId = ConfigurationManager.AppSettings["ida:CSPApplicationId"];
@@ -28,28 +41,32 @@ namespace CSPApplication
 
         private static void Main(string[] args)
         {
-            Task.Run(() => Run()).Wait();
+            serviceClient = new PartnerServiceClient(httpClient);
+            RunAsync().ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
-        private static async Task Run()
+        private static async Task RunAsync()
         {
             // The following properties indicate which partner and customer context the calls are going to be made.
             string PartnerId = "<Partner tenant id>";
             string CustomerId = "<Customer tenant id>";
 
-            Console.WriteLine(" ===================== Partner center  API calls ============================", DateTime.Now);
+            Console.WriteLine(" ===================== Partner Center operations ============================", DateTime.Now);
             IAggregatePartner ops = await GetUserPartnerOperationsAsync(PartnerId);
             SeekBasedResourceCollection<CustomerUser> customerUsers = ops.Customers.ById(CustomerId).Users.Get();
             Console.WriteLine(JsonConvert.SerializeObject(customerUsers));
 
-            Console.WriteLine(" ===================== Partner graph  API calls ============================", DateTime.Now);
+            Console.WriteLine(" ===================== Partner graph operations ============================", DateTime.Now);
             Tuple<string, DateTimeOffset> tokenResult = await LoginToGraph(PartnerId);
             Newtonsoft.Json.Linq.JObject mydetails = await ApiCalls.GetAsync(tokenResult.Item1, "https://graph.microsoft.com/v1.0/me");
             Console.WriteLine(JsonConvert.SerializeObject(mydetails));
 
-            // CSP partner applications are pre-consented into customer tenant, so they do not need a custom consent from customer.
-            // direct token acquire to a customer tenant should work.
-            Console.WriteLine(" ===================== Customer graph  API calls ============================", DateTime.Now);
+            /**
+             * Cloud Solution Provider partners can configure application for pre-consent. This means they do not need a 
+             * custom consent from the customer. This is possible because the partner can consent on behalf of the customer.
+             */
+
+            Console.WriteLine(" ===================== Customer graph operations ============================", DateTime.Now);
             Tuple<string, DateTimeOffset> tokenCustomerResult = await LoginToCustomerGraph(PartnerId, CustomerId);
             Newtonsoft.Json.Linq.JObject customerDomainsUsingGraph = await ApiCalls.GetAsync(tokenCustomerResult.Item1, "https://graph.windows.net/" + CustomerId + "/domains?api-version=1.6");
             Console.WriteLine(JsonConvert.SerializeObject(customerDomainsUsingGraph));
@@ -62,38 +79,36 @@ namespace CSPApplication
             KeyVaultProvider provider = new KeyVaultProvider();
             string refreshToken = await provider.GetSecretAsync(tenantId);
 
-            Newtonsoft.Json.Linq.JObject token = await AuthorizationUtilities.GetAADTokenFromRefreshToken(
-                "https://login.microsoftonline.com/" + tenantId,
+            AuthenticationResult token = await serviceClient.RefreshAccessTokenAsync(
+                $"https://login.microsoftonline.com/{tenantId}/oauth2/token",
                 "https://api.partnercenter.microsoft.com",
+                refreshToken,
                 CSPApplicationId,
-                CSPApplicationSecret,
-                refreshToken);
+                CSPApplicationSecret).ConfigureAwait(false);
 
-            return new Tuple<string, DateTimeOffset>(token["access_token"].ToString(), DateTimeOffset.UtcNow + TimeSpan.FromTicks(long.Parse(token["expires_on"].ToString())));
+            return new Tuple<string, DateTimeOffset>(token.AccessToken, token.ExpiresOn);
         }
 
         /// <summary>
-        /// Generates a token for Partner tenant using partner user refresh token
-        /// The expiry time calculation explined below is not strong. 
-        /// please use stardard ADAL library to gain access token by refresh token, which provides strongly typed classes with proper expirty time calculation.
+        /// Generates a token for the partner tenant using a refresh token.
         /// </summary>
-        /// <param name="partnerTenantId">partner tenant id</param>
+        /// <param name="tenantId">partner tenant id</param>
         /// <returns>
         /// Access token and expiry time. 
         /// </returns>
-        public static async Task<Tuple<string, DateTimeOffset>> LoginToGraph(string partnerTenantId)
+        public static async Task<Tuple<string, DateTimeOffset>> LoginToGraph(string tenantId)
         {
             KeyVaultProvider provider = new KeyVaultProvider();
-            string refreshToken = await provider.GetSecretAsync(partnerTenantId);
+            string refreshToken = await provider.GetSecretAsync(tenantId);
 
-            Newtonsoft.Json.Linq.JObject token = await AuthorizationUtilities.GetAADTokenFromRefreshToken(
-                "https://login.microsoftonline.com/" + partnerTenantId,
+            AuthenticationResult token = await serviceClient.RefreshAccessTokenAsync(
+                $"https://login.microsoftonline.com/{tenantId}/oauth2/token",
                 "https://graph.microsoft.com",
+                refreshToken,
                 CSPApplicationId,
-                CSPApplicationSecret,
-                refreshToken);
+                CSPApplicationSecret).ConfigureAwait(false);
 
-            return new Tuple<string, DateTimeOffset>(token["access_token"].ToString(), DateTimeOffset.UtcNow + TimeSpan.FromTicks(long.Parse(token["expires_on"].ToString())));
+            return new Tuple<string, DateTimeOffset>(token.AccessToken, token.ExpiresOn);
         }
 
         /// <summary>
@@ -111,14 +126,14 @@ namespace CSPApplication
             KeyVaultProvider provider = new KeyVaultProvider();
             string refreshToken = await provider.GetSecretAsync(partnerTenantId);
 
-            Newtonsoft.Json.Linq.JObject token = await AuthorizationUtilities.GetAADTokenFromRefreshToken(
-                "https://login.microsoftonline.com/" + customerTenantId,
+            AuthenticationResult token = await serviceClient.RefreshAccessTokenAsync(
+                $"https://login.microsoftonline.com/{customerTenantId}/oauth2/token",
                 "https://graph.windows.net",
+                refreshToken,
                 CSPApplicationId,
-                CSPApplicationSecret,
-                refreshToken);
+                CSPApplicationSecret).ConfigureAwait(false);
 
-            return new Tuple<string, DateTimeOffset>(token["access_token"].ToString(), DateTimeOffset.UtcNow + TimeSpan.FromTicks(long.Parse(token["expires_on"].ToString())));
+            return new Tuple<string, DateTimeOffset>(token.AccessToken, token.ExpiresOn);
         }
 
         /// <summary>

--- a/secure-app-model/keyvault/CSPApplication/Utilities/AuthorizationUtilities.cs
+++ b/secure-app-model/keyvault/CSPApplication/Utilities/AuthorizationUtilities.cs
@@ -15,34 +15,6 @@ namespace CSPApplication.Utilities
     public static class AuthorizationUtilities
     {
         /// <summary>
-        /// Gets AAD token in refresh token flow
-        /// </summary>
-        /// <param name="authority">AAD authority</param>
-        /// <param name="audience">Token audience</param>
-        /// <param name="clientId">Marketplace application id </param>
-        /// <param name="clientSecret">Marketplace application secret</param>
-        /// <param name="refreshToken">refresh token</param>
-        /// <returns></returns>
-        public static async Task<JObject> GetAADTokenFromRefreshToken(string authority, string audience, string clientId, string clientSecret, string refreshToken)
-        {
-            string loginUrl = string.Format("{0}/oauth2/token", authority);
-
-            WebRequest request = WebRequest.Create(loginUrl);
-
-            request.Method = "POST";
-            request.ContentType = "application/x-www-form-urlencoded";
-
-            string content = string.Format(
-                "resource={0}&client_id={1}&client_secret={2}&grant_type=refresh_token&refresh_token={3}&scope=openid",
-                HttpUtility.UrlEncode(audience),
-                HttpUtility.UrlEncode(clientId),
-                HttpUtility.UrlEncode(clientSecret),
-                HttpUtility.UrlEncode(refreshToken));
-
-            return await GetResponse(request, content);
-        }
-
-        /// <summary>
         /// Gets AAD token in application only token in non-interactive service principal flow
         /// </summary>
         /// <param name="authority">AAD authority</param>

--- a/secure-app-model/keyvault/CSPApplication/Utilities/KeyVaultProvider.cs
+++ b/secure-app-model/keyvault/CSPApplication/Utilities/KeyVaultProvider.cs
@@ -11,6 +11,7 @@ namespace CSPApplication.Utilities
     using Microsoft.Azure.KeyVault;
     using Microsoft.Azure.KeyVault.Models;
     using Newtonsoft.Json.Linq;
+    using System.Net.Http;
 
     /// <summary>
     /// Provider for accessing secrets from the Azure KeyVault
@@ -21,16 +22,22 @@ namespace CSPApplication.Utilities
         private readonly string KeyVaultClientSecret = ConfigurationManager.AppSettings["ida:KeyVaultClientSecret"];
         private readonly string BaseUrl = ConfigurationManager.AppSettings["KeyVaultEndpoint"];
 
+        /// <summary>
+        /// The client used to perform HTTP operations.
+        /// </summary>
+        private readonly static HttpClient httpClient = new HttpClient();
+
         public async Task<string> GetSecretAsync(string key)
         {
-            KeyVaultClient keyVault = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(this.GetToken), new System.Net.Http.HttpClient());
-            SecretBundle secret = await keyVault.GetSecretAsync(this.BaseUrl, key.Replace("@", string.Empty).Replace(".", string.Empty));
+            KeyVaultClient keyVault = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(GetToken), httpClient);
+
+            SecretBundle secret = await keyVault.GetSecretAsync(BaseUrl, key.Replace("@", string.Empty).Replace(".", string.Empty));
             return secret.Value;
         }
 
         private async Task<string> GetToken(string authority, string resource, string scope)
         {
-            JObject tokenResult = await AuthorizationUtilities.GetADAppToken(authority, resource, this.KeyVaultClientId, this.KeyVaultClientSecret);
+            JObject tokenResult = await AuthorizationUtilities.GetADAppToken(authority, resource, KeyVaultClientId, KeyVaultClientSecret);
             return tokenResult["access_token"].ToString();
         }
     }

--- a/secure-app-model/keyvault/CSPApplication/packages.config
+++ b/secure-app-model/keyvault/CSPApplication/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.KeyVault" version="3.0.1" targetFramework="net461" />
-  <package id="Microsoft.Azure.KeyVault.WebKey" version="3.0.1" targetFramework="net461" />
-  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="4.4.0" targetFramework="net461" />
+  <package id="Microsoft.Azure.KeyVault" version="3.0.2" targetFramework="net461" />
+  <package id="Microsoft.Azure.KeyVault.WebKey" version="3.0.2" targetFramework="net461" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="4.4.2" targetFramework="net461" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.18" targetFramework="net461" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.18" targetFramework="net461" />
   <package id="Microsoft.Store.PartnerCenter" version="1.10.0" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net461" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net461" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net461" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />

--- a/secure-app-model/keyvault/PartnerConsent/Controllers/HomeController.cs
+++ b/secure-app-model/keyvault/PartnerConsent/Controllers/HomeController.cs
@@ -6,7 +6,9 @@
 
 namespace PartnerConsent.Controllers
 {
+    using System.Security.Claims;
     using System.Web.Mvc;
+    using System.Linq;
 
     [Authorize]
     public class HomeController : Controller
@@ -17,7 +19,9 @@ namespace PartnerConsent.Controllers
         /// <returns></returns>
         public ActionResult Index()
         {
-            return View();
+            ClaimsIdentity identity = HttpContext.User.Identity as ClaimsIdentity;
+
+            return View(identity.Claims.Where(m => m.Type.Equals(@"http://schemas.microsoft.com/claims/authnmethodsreferences")));
         }
 
         /// <summary>

--- a/secure-app-model/keyvault/PartnerConsent/PartnerConsent.csproj
+++ b/secure-app-model/keyvault/PartnerConsent/PartnerConsent.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props')" />
+  <Import Project="..\packages\Microsoft.Net.Compilers.2.10.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.10.0\build\Microsoft.Net.Compilers.props')" />
   <Import Project="..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -52,10 +52,10 @@
       <HintPath>..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.KeyVault, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.KeyVault.3.0.1\lib\net452\Microsoft.Azure.KeyVault.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Azure.KeyVault.3.0.2\lib\net452\Microsoft.Azure.KeyVault.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.WebKey, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.KeyVault.WebKey.3.0.1\lib\net452\Microsoft.Azure.KeyVault.WebKey.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Azure.KeyVault.WebKey.3.0.2\lib\net452\Microsoft.Azure.KeyVault.WebKey.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
@@ -103,8 +103,8 @@
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
@@ -128,26 +128,26 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.6\lib\net45\System.Web.Helpers.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.Helpers.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Mvc, Version=5.2.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.6\lib\net45\System.Web.Mvc.dll</HintPath>
+    <Reference Include="System.Web.Mvc, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.7\lib\net45\System.Web.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Optimization, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.6\lib\net45\System.Web.Razor.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.7\lib\net45\System.Web.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.6\lib\net45\System.Web.WebPages.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.6\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.6\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
@@ -201,6 +201,9 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
@@ -230,7 +233,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.10.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.10.0\build\Microsoft.Net.Compilers.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/secure-app-model/keyvault/PartnerConsent/Views/Home/Index.cshtml
+++ b/secure-app-model/keyvault/PartnerConsent/Views/Home/Index.cshtml
@@ -1,4 +1,6 @@
-﻿@inherits System.Web.Mvc.WebViewPage
+﻿@using System.Collections.Generic;
+@using System.Linq
+@using System.Security.Claims
 
 <div>
     <h1>Partner Consent</h1>
@@ -14,6 +16,20 @@
         </p>
         <p>
             <a href="javascript:window.open('','_self').close();">close</a>
+        </p>
+        <p>
+
+            @{ 
+                IEnumerable<Claim> claims = Model;
+                Claim mfaClaim = claims.FirstOrDefault(c => c.Value.Equals("mfa", StringComparison.InvariantCultureIgnoreCase));
+
+                if (mfaClaim == null)
+                {
+                    <p>
+                        <strong style="color: red;">Warning</strong> You have not authenticated using multi-factor authentication.
+                    </p>
+                }
+            }
         </p>
     </div>
 </div>

--- a/secure-app-model/keyvault/PartnerConsent/Web.config
+++ b/secure-app-model/keyvault/PartnerConsent/Web.config
@@ -38,20 +38,8 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-5.2.6.0" newVersion="5.2.6.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -76,6 +64,18 @@
       <dependentAssembly>
         <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/secure-app-model/keyvault/PartnerConsent/packages.config
+++ b/secure-app-model/keyvault/PartnerConsent/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net461" />
-  <package id="Microsoft.AspNet.Mvc" version="5.2.6" targetFramework="net461" />
-  <package id="Microsoft.AspNet.Razor" version="3.2.6" targetFramework="net461" />
+  <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net461" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net461" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net461" />
-  <package id="Microsoft.AspNet.WebPages" version="3.2.6" targetFramework="net461" />
-  <package id="Microsoft.Azure.KeyVault" version="3.0.1" targetFramework="net461" />
-  <package id="Microsoft.Azure.KeyVault.WebKey" version="3.0.1" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net461" />
+  <package id="Microsoft.Azure.KeyVault" version="3.0.2" targetFramework="net461" />
+  <package id="Microsoft.Azure.KeyVault.WebKey" version="3.0.2" targetFramework="net461" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net461" />
   <package id="Microsoft.IdentityModel.JsonWebTokens" version="5.3.0" targetFramework="net461" />
   <package id="Microsoft.IdentityModel.Logging" version="5.3.0" targetFramework="net461" />
@@ -14,7 +14,7 @@
   <package id="Microsoft.IdentityModel.Protocols" version="5.3.0" targetFramework="net461" />
   <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.3.0" targetFramework="net461" />
   <package id="Microsoft.IdentityModel.Tokens" version="5.3.0" targetFramework="net461" />
-  <package id="Microsoft.Net.Compilers" version="2.9.0" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.Net.Compilers" version="2.10.0" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.Owin" version="4.0.0" targetFramework="net461" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="4.0.0" targetFramework="net461" />
   <package id="Microsoft.Owin.Security" version="4.0.0" targetFramework="net461" />
@@ -23,7 +23,7 @@
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.18" targetFramework="net461" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.18" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net461" />
   <package id="Owin" version="1.0" targetFramework="net461" />
   <package id="System.IdentityModel.Tokens.Jwt" version="5.3.0" targetFramework="net461" />
   <package id="WebGrease" version="1.6.0" targetFramework="net461" />


### PR DESCRIPTION
# Description

Through this pull request the following changes are being made 

1. Added a warning statement if the partner consent process is performed using an account with MFA
2. Added models for the authentication in the CSP sample. These models include the correct expiration time for tokens.
3. Refactored the CSP sample to include a service client that will handle common HTTP errors
4. Update the NuGet packages for the CSP sample application and partner consent projects

## Related issue

#13 