### PR TITLE
Adding the code owners configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @brijeshp-ms, @kaminasy, or @isaiahwilliams will be requested for
+# review when someone opens a pull request.
+*       @brijeshp-ms @kaminasy @isaiahwilliams 


### PR DESCRIPTION
# Description

Through this pull request [code owners](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) are being specified. 

## Related issue

Kindly link any related issues (e.g. Fixes #xyz).