### PR TITLE
Changes to samples to exercise new properties of Transitions and Update Subscription

### DIFF
--- a/sdk/SdkSamples/Subscriptions/TransitionSubscription.cs
+++ b/sdk/SdkSamples/Subscriptions/TransitionSubscription.cs
@@ -6,8 +6,8 @@
 
 namespace Microsoft.Store.PartnerCenter.Samples.Subscriptions
 {
-    using Microsoft.Store.PartnerCenter.Models.Subscriptions;
     using System.Linq;
+    using Microsoft.Store.PartnerCenter.Models.Subscriptions;
 
     /// <summary>
     /// A scenario that transitions a customer subscription to a higher sku.

--- a/sdk/SdkSamples/Subscriptions/UpdateSubscription.cs
+++ b/sdk/SdkSamples/Subscriptions/UpdateSubscription.cs
@@ -4,11 +4,11 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-using Microsoft.Store.PartnerCenter.Models.Offers;
-using System;
-
 namespace Microsoft.Store.PartnerCenter.Samples.Subscriptions
 {
+    using System;
+    using Microsoft.Store.PartnerCenter.Models.Offers;
+
     /// <summary>
     /// A scenario that updates an existing customer subscription.
     /// </summary>

--- a/sdk/SdkSamples/Subscriptions/UpdateSubscription.cs
+++ b/sdk/SdkSamples/Subscriptions/UpdateSubscription.cs
@@ -4,6 +4,9 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using Microsoft.Store.PartnerCenter.Models.Offers;
+using System;
+
 namespace Microsoft.Store.PartnerCenter.Samples.Subscriptions
 {
     /// <summary>
@@ -33,8 +36,26 @@ namespace Microsoft.Store.PartnerCenter.Samples.Subscriptions
             this.Context.ConsoleHelper.StopProgress();
             this.Context.ConsoleHelper.WriteObject(existingSubscription, "Existing subscription");
 
-            this.Context.ConsoleHelper.StartProgress("Incrementing subscription quantity");
-            existingSubscription.Quantity++;
+            string targetQuantity = this.Context.ConsoleHelper.ReadOptionalString("Enter target quantity or leave blank to keep quantity the same");
+            if (!string.IsNullOrWhiteSpace(targetQuantity)) {
+                existingSubscription.Quantity = int.Parse(targetQuantity);
+            }
+
+            string targetTermDuration = this.Context.ConsoleHelper.ReadOptionalString("Enter a new term duration or leave blank to keep the same [example: P1Y, P1M]");
+
+            if (!string.IsNullOrWhiteSpace(targetTermDuration))
+            {
+                existingSubscription.TermDuration = targetTermDuration;
+
+                string targetBillingCycle = this.Context.ConsoleHelper.ReadOptionalString("Enter a new billing cycle or leave blank to keep the same [example: Annual or Monthly]");
+
+                if (!string.IsNullOrWhiteSpace(targetBillingCycle))
+                {
+                    existingSubscription.BillingCycle = (BillingCycleType)Enum.Parse(typeof(BillingCycleType), targetBillingCycle, true);
+                }
+            }
+
+            this.Context.ConsoleHelper.StartProgress("Updating subscription");
             var updatedSubscription = partnerOperations.Customers.ById(customerId).Subscriptions.ById(subscriptionId).Patch(existingSubscription);
             this.Context.ConsoleHelper.StopProgress();
 


### PR DESCRIPTION
# Description

TermDuration and BillingCycle properties have been added to the Post:Transitions and Patch:Subscription. This PR has the changes to the samples showing those properties being used.

## Related issue
