### PR TITLE
Adding examples for Custom Term End Date during Migrations + Promotion Eligibilities with null PromotionId.

### DIFF
--- a/sdk/SdkSamples/BasePartnerScenario.cs
+++ b/sdk/SdkSamples/BasePartnerScenario.cs
@@ -534,6 +534,23 @@ namespace Microsoft.Store.PartnerCenter.Samples
         }
 
         /// <summary>
+        /// Obtains a custom term end date to work with by prompting the user to enter it.
+        /// </summary>
+        /// <param name="promptMessage">An optional custom prompt message.</param>
+        /// <returns>The custom term end date.</returns>
+        protected DateTime? ObtainCustomTermEndDate(string promptMessage = default(string))
+        {
+            string customTermEndDateString = this.Context.ConsoleHelper.ReadOptionalString(string.IsNullOrWhiteSpace(promptMessage) ? "Enter a custom term end date or leave blank to keep default" : promptMessage);
+            DateTime? customTermEndDate = null;
+            if (!string.IsNullOrWhiteSpace(customTermEndDateString))
+            {
+                customTermEndDate = DateTime.Parse(customTermEndDateString);
+            }
+
+            return customTermEndDate;
+        }
+
+        /// <summary>
         /// Obtains a value to work with from the configuration if set there or prompts the user to enter it.
         /// </summary>
         /// <param name="configuredValue">The value read from the configuration.</param>

--- a/sdk/SdkSamples/NewCommerceMigrations/ValidateAndCreateNewCommerceMigration.cs
+++ b/sdk/SdkSamples/NewCommerceMigrations/ValidateAndCreateNewCommerceMigration.cs
@@ -30,10 +30,19 @@ namespace Microsoft.Store.PartnerCenter.Samples.NewCommerceMigrations
 
             string customerId = this.ObtainCustomerId("Enter the ID of the customer making the purchase");
             string subscriptionId = this.ObtainSubscriptionId(customerId, "Enter the ID of the subscription to be migrated to New-Commerce");
+            string termDuration = this.ObtainRenewalTermDuration("Enter a term duration for the subscription [example: P1Y, P1M]");
+            string billingCycle = this.ObtainBillingCycle("Enter a billing cycle for the subscription [example: Annual or Monthly]");
+            string quantityString = this.ObtainQuantity("Enter the quantity for the subscription");
+            var quantity = int.Parse(quantityString);
+            var customTermEndDate = this.ObtainCustomTermEndDate("Enter the custom term end date for the subscription or leave blank to keep default");
 
             var newCommerceMigration = new NewCommerceMigration()
             {
                 CurrentSubscriptionId = subscriptionId,
+                TermDuration = termDuration,
+                BillingCycle = billingCycle,
+                Quantity = quantity,
+                CustomTermEndDate = customTermEndDate,
             };
 
             var newCommerceMigrationOperations = partnerOperations.Customers.ById(customerId).NewCommerceMigrations;

--- a/sdk/SdkSamples/NewCommerceMigrations/ValidateAndCreateNewCommerceMigrationWithAddOn.cs
+++ b/sdk/SdkSamples/NewCommerceMigrations/ValidateAndCreateNewCommerceMigrationWithAddOn.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Store.PartnerCenter.Samples.NewCommerceMigrations
         {
             var partnerOperations = this.Context.UserPartnerOperations;
 
-            string customerId = this.ObtainCustomerId("Enter the ID of the customer making the purchase");       
+            string customerId = this.ObtainCustomerId("Enter the ID of the customer making the purchase");
             string subscriptionId = this.ObtainSubscriptionId(customerId, "Enter the ID of the subscription to be migrated to New-Commerce");
             string subscriptionTermDuration = this.ObtainRenewalTermDuration("Enter a term duration for the subscription [example: P1Y, P1M]");
             string subscriptionBillingCycle = this.ObtainBillingCycle("Enter a billing cycle for the subscription [example: Annual or Monthly]");

--- a/sdk/SdkSamples/NewCommerceMigrations/ValidateAndCreateNewCommerceMigrationWithAddOn.cs
+++ b/sdk/SdkSamples/NewCommerceMigrations/ValidateAndCreateNewCommerceMigrationWithAddOn.cs
@@ -30,8 +30,13 @@ namespace Microsoft.Store.PartnerCenter.Samples.NewCommerceMigrations
         {
             var partnerOperations = this.Context.UserPartnerOperations;
 
-            string customerId = this.ObtainCustomerId("Enter the ID of the customer making the purchase");
+            string customerId = this.ObtainCustomerId("Enter the ID of the customer making the purchase");       
             string subscriptionId = this.ObtainSubscriptionId(customerId, "Enter the ID of the subscription to be migrated to New-Commerce");
+            string subscriptionTermDuration = this.ObtainRenewalTermDuration("Enter a term duration for the subscription [example: P1Y, P1M]");
+            string subscriptionBillingCycle = this.ObtainBillingCycle("Enter a billing cycle for the subscription [example: Annual or Monthly]");
+            string subscriptionQuantityString = this.ObtainQuantity("Enter the quantity for the subscription");
+            var subscriptionQuantity = int.Parse(subscriptionQuantityString);
+            var subscriptionCustomTermEndDate = this.ObtainCustomTermEndDate("Enter the custom term end date for the subscription or leave blank to keep default");
 
             string addOnSubscriptionId = this.ObtainSubscriptionId(customerId, "Enter the ID of the add-on subscription to be migrated to New-Commerce");
 
@@ -44,10 +49,15 @@ namespace Microsoft.Store.PartnerCenter.Samples.NewCommerceMigrations
             string addOnSubscriptionBillingCycle = this.ObtainBillingCycle("Enter a billing cycle for the add-on subscription [example: Annual or Monthly]");
             string addOnSubscriptionQuantityString = this.ObtainQuantity("Enter the quantity for the add-on subscription");
             var addOnSubscriptionQuantity = int.Parse(addOnSubscriptionQuantityString);
+            var addonSubscriptionCustomTermEndDate = this.ObtainCustomTermEndDate("Enter the custom term end date for the add-on subscription or leave blank to keep default");
 
             var newCommerceMigration = new NewCommerceMigration
             {
                 CurrentSubscriptionId = subscriptionId,
+                TermDuration = subscriptionTermDuration,
+                BillingCycle = subscriptionBillingCycle,
+                Quantity = subscriptionQuantity,
+                CustomTermEndDate = subscriptionCustomTermEndDate,
                 AddOnMigrations = new List<NewCommerceMigration>
                 {
                     new NewCommerceMigration
@@ -56,6 +66,7 @@ namespace Microsoft.Store.PartnerCenter.Samples.NewCommerceMigrations
                         TermDuration = addOnSubscriptionTermDuration,
                         BillingCycle = addOnSubscriptionBillingCycle,
                         Quantity = addOnSubscriptionQuantity,
+                        CustomTermEndDate = addonSubscriptionCustomTermEndDate,
                     }
                 },
             };

--- a/sdk/SdkSamples/Orders/CreateOrder.cs
+++ b/sdk/SdkSamples/Orders/CreateOrder.cs
@@ -45,11 +45,7 @@ namespace Microsoft.Store.PartnerCenter.Samples.Orders
             string quantityString = this.ObtainQuantity();
             var quantity = int.Parse(quantityString);
             
-            string customTermEndDateString = this.Context.ConsoleHelper.ReadOptionalString("Enter a custom term end date or leave blank to keep default");
-            DateTime? customTermEndDate = null;
-            if (!string.IsNullOrWhiteSpace(customTermEndDateString)) {
-                customTermEndDate = DateTime.Parse(customTermEndDateString);
-            }
+            DateTime? customTermEndDate = this.ObtainCustomTermEndDate();
             
             var order = new Order()
             {

--- a/sdk/SdkSamples/PromotionEligibilities/PostPromotionEligibilities.cs
+++ b/sdk/SdkSamples/PromotionEligibilities/PostPromotionEligibilities.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Store.PartnerCenter.Samples.PromotionEligibilities
             string termDuration = this.ObtainRenewalTermDuration("Enter the term duration");
             string billingCycle = this.ObtainBillingCycle("Enter the billing cycle");
             var billingCycleType = (BillingCycleType)Enum.Parse(typeof(BillingCycleType), billingCycle, true);
-            var promotionId = this.Context.ConsoleHelper.ReadNonEmptyString("Enter the promotionId", "The promotionId can't be empty");
+            var promotionId = this.Context.ConsoleHelper.ReadOptionalString("Enter the promotionId or leave blank to get eligibility for for all active and applicable promotions");
 
             var promotionEligibilityRequest = new PromotionEligibilitiesRequest()
             {

--- a/sdk/SdkSamples/Subscriptions/UpdateSubscriptionScheduledChange.cs
+++ b/sdk/SdkSamples/Subscriptions/UpdateSubscriptionScheduledChange.cs
@@ -88,12 +88,7 @@ namespace Microsoft.Store.PartnerCenter.Samples.Subscriptions
                     var changeToQuantity = int.Parse(quantity);
                     
                     // prompt the user to enter the custom term end date for the scheduled change
-                    string customTermEndDate = this.Context.ConsoleHelper.ReadOptionalString("Enter the scheduled change custom term end date or leave blank to keep the current term end date");
-                    DateTime? changeToCustomTermEndDate = null;
-                    
-                    if (!string.IsNullOrWhiteSpace(customTermEndDate)) {
-                        changeToCustomTermEndDate = DateTime.Parse(customTermEndDate);
-                    }
+                    DateTime? changeToCustomTermEndDate = this.ObtainCustomTermEndDate("Enter the scheduled change custom term end date or leave blank to keep the current term end date");
                     
                     this.Context.ConsoleHelper.StartProgress("Updating subscription scheduled change");
                     selectedSubscription.ScheduledNextTermInstructions = new ScheduledNextTermInstructions


### PR DESCRIPTION
# Description

Adding examples for Custom Term End Date during Migrations + Promotion Eligibilities with null PromotionId

## Related issue

Kindly link any related issues (e.g. Fixes #xyz).