### PR TITLE
Update account page link to V2

### DIFF
--- a/MCARefreshBulkAttestationCLITool/Models/CustomerAgreementRecord.cs
+++ b/MCARefreshBulkAttestationCLITool/Models/CustomerAgreementRecord.cs
@@ -36,7 +36,7 @@ namespace MCARefreshBulkAttestationCLITool.Models
 
         public string CustomerAccountLink
         {
-            get => $"https://partner.microsoft.com/en-us/dashboard/commerce2/customers/{this.CustomerTenantId}/account";
+            get => $"https://partner.microsoft.com/dashboard/v2/customers/{this.CustomerTenantId}/account";
         }
     }
 }


### PR DESCRIPTION
# Description

Changing the account link to use the `v2` route.